### PR TITLE
Gemify Jekyll-Staging for easier distribution.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gemspec

--- a/README.markdown
+++ b/README.markdown
@@ -5,12 +5,12 @@ by [Matt Gemmell](http://mattgemmell.com/)
 
 ## What is it?
 
-It's a Ruby script that stages and unstages draft posts for Jekyll's internal server.
+It's a Ruby gem that stages and unstages draft posts for Jekyll's internal server.
 
 
 ## What are its requirements?
 
-Just Ruby itself.
+All you need is Ruby. Grab it by running `gem install jekyll-staging` in your terminal.
 
 
 ## What does it do?
@@ -40,21 +40,21 @@ Then, run the script without any arguments to see usage instructions.
 
 Basically:
 
-- **`./stage.rb FILENAME_GLOB`** stages the first matching draft.
-- **`./stage.rb -u`** unstages the first staged post.
-- **`./stage.rb -u FILENAME_GLOB`** unstages the first matching staged post.
+- **`stage FILENAME_GLOB`** stages the first matching draft.
+- **`stage -u`** unstages the first staged post.
+- **`stage -u FILENAME_GLOB`** unstages the first matching staged post.
 
 You don't need to specify full paths, because it'll be looking in your drafts folder anyway. Feel free to use partial filenames, and shell glob patterns. If there's more than one match, it'll use the first one, and it'll output the full list of matches as well as the filename it chose.
 
 Let's say you had a draft whose filename was `got-a-new-iphone.markdown`. A typical workflow would be:
 
-1. **`./stage.rb iphone`** (stage the draft for Jekyll)
+1. **`stage iphone`** (stage the draft for Jekyll)
 
 2. **`jekyll serve`** (start the built-in web server, changing to your Jekyll directory first)
 
 3. Edit your post as you see fit, and view it in your browser. When you're done, kill Jekyll's web server.
 
-4. **`./stage.rb -u`** (unstage the draft, putting it back in your drafts folder)
+4. **`stage -u`** (unstage the draft, putting it back in your drafts folder)
 
 You can then decide whether to publish the post, and build and deploy your site as usual.
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,2 @@
+require "bundler/gem_tasks"
+

--- a/bin/stage
+++ b/bin/stage
@@ -32,15 +32,36 @@
 # Configuration
 # ========================================
 
+# Load in configuration file, or ask and populate.
+def read_or_ask_for_configuration
+  require 'yaml'
+  conf_file = File.join(ENV['HOME'], '.jekyll-stagingrc')
+  if File.exist?(conf_file)
+    YAML.load_file(conf_file)
+  else
+    conf = {}
+    print "Where is your Jekyll site located? (full path, '~' is ok) "
+    conf['jekyll_root'] = STDIN.gets
+    print "Where are your drafts located? (full path, '~' is ok) "
+    conf['drafts_dir'] = STDIN.gets
+    print "What file extension do you use for your drafts and posts? (no period) "
+    conf['file_extension'] = STDIN.gets
+    File.open(conf_file, 'wb') { |f| f.write(YAML.dump(conf)) }
+    conf
+  end
+end
+
+
+configuration = read_or_ask_for_configuration
 
 # Your Jekyll site's local root directory (it has the "_config.yml" file in it).
-$jekyll_root = "~/Dropbox/blog/mattgemmell.com" # full path ("~" is OK too)
+$jekyll_root  = configuration['jekyll_root']
 
 # Wherever you keep your local in-progress drafts, outside of your Jekyll site.
-$drafts_dir = "~/Dropbox/writing/blog" # full path ("~" is OK too)
+$drafts_dir = configuration['drafts_dir']
 
 # File-extension for your drafts and post files.
-$file_extension = "markdown" # without period (use "*" for all)
+$file_extension = configuration['file_extension']
 
 # Note: It's assumed that your drafts' filenames DON'T have date-prefixes.
 

--- a/bin/stage
+++ b/bin/stage
@@ -1,21 +1,20 @@
-#!/usr/bin/ruby
-
+#!/usr/bin/env ruby
 
 # Staging/unstaging script for Jekyll blog posts.
-# 
+#
 # by Matt Gemmell
-# 
+#
 # Web: http://mattgemmell.com
 # Twitter: http://twitter.com/mattgemmell
 
 
 # This script moves a specified draft post into Jekyll's folder structure,
 # and temporarily stashes all other posts so the site will build quickly.
-# 
+#
 # This is for people who keep their drafts outside of Jekyll's folder structure.
-# 
+#
 # It can also reverse the process when you're done, of course.
-# 
+#
 # This is useful when you're working on a post using Jekyll's server.
 
 
@@ -72,7 +71,7 @@ def first_matching_file_in_dir(the_filename_glob, the_dir_path)
 	elsif matches.count > 1
 		puts "Found #{matches.count} matching files (#{matches.join(", ")})"
 	end
-	
+
 	filename = matches[0]
 	puts "Using file \"#{filename}\"."
 	return filename
@@ -81,7 +80,7 @@ end
 
 def directory_exists(the_dir_path)
 	# Check for a directory at path.
-	
+
 	if File.exist?(the_dir_path)
 		# Something's there. Check if it's a directory.
 		#puts "Found something at given path."
@@ -94,14 +93,14 @@ def directory_exists(the_dir_path)
 			#puts "It's not a directory"
 		end
 	end
-	
+
 	return false
 end
 
 
 def create_dir_if_necessary(the_dir_path)
 	# Check for a directory at path, creating it if necessary.
-	
+
 	# Check to see if an item exists at that path.
 	if directory_exists(the_dir_path)
 		return true
@@ -118,18 +117,18 @@ def create_dir_if_necessary(the_dir_path)
 			return false
 		end
 	end
-	
+
 	return false
 end
 
 
 def isolate(the_filename_glob)
 	# Moves all files from posts to stash, except those matching the glob.
-	
+
 	# Move all files from posts into stash.
 	cmd = "mv #{$posts_dir}/*.#{$file_extension} #{$stash_dir}/"
 	result = `#{cmd}`
-	
+
 	# Move the matching files back into posts.
 	cmd = "mv #{$stash_dir}/*#{the_filename_glob}* #{$posts_dir}/"
 	result = `#{cmd}`
@@ -138,7 +137,7 @@ end
 
 def integrate()
 	# Moves all files from stash back into posts.
-	
+
 	# Move all files from stash into posts.
 	cmd = "mv #{$stash_dir}/*.#{$file_extension} #{$posts_dir}/"
 	result = `#{cmd}`
@@ -147,9 +146,9 @@ end
 
 def stage_file(the_filename_glob)
 	# Stages the given file.
-	
+
 	puts "Staging \"#{the_filename_glob}\"…"
-	
+
 	# Grab specified file (glob) from drafts folder.
 	full_glob = "*#{the_filename_glob}*.#{$file_extension}"
 	filename = first_matching_file_in_dir(full_glob, $drafts_dir)
@@ -157,32 +156,32 @@ def stage_file(the_filename_glob)
 		puts "Couldn't find a file to stage. Aborting."
 		exit
 	end
-	
+
 	# Move file to posts directory, prefixing its filename with today's date.
 	require "Date"
 	today = DateTime.now()
 	prefix = today.strftime($file_date_prefix_format)
 	new_filename = "#{prefix}#{filename}"
-	
+
 	cmd = "mv #{$drafts_dir}/#{filename} #{$posts_dir}/#{new_filename}"
 	result = `#{cmd}`
-	
+
 	# Isolate the staged file in posts, moving all other posts to stash.
 	isolate(new_filename)
-	
+
 	puts "File staged as \"#{new_filename}\"."
 end
 
 
 def unstage_file(the_filename_glob)
 	# Unstages the given file, or the first staged file if none is specified.
-	
+
 	if (the_filename_glob)
 		puts "Unstaging \"#{the_filename_glob}\"…"
 	else
 		puts "Unstaging first staged file…"
 	end
-	
+
 	# Grab specified file (glob) from posts folder.
 	if (the_filename_glob)
 		full_glob = "*#{the_filename_glob}*.#{$file_extension}"
@@ -194,16 +193,16 @@ def unstage_file(the_filename_glob)
 		puts "Couldn't find a file to unstage. Aborting."
 		exit
 	end
-	
+
 	# Move file to drafts directory, removing date from its filename.
 	new_filename = filename.sub($file_date_prefix_regexp, "")
-	
+
 	cmd = "mv #{$posts_dir}/#{filename} #{$drafts_dir}/#{new_filename}"
 	result = `#{cmd}`
-	
+
 	# Move all stashed files back into posts.
 	integrate()
-	
+
 	puts "Unstaging complete."
 end
 

--- a/jekyll-staging.gemspec
+++ b/jekyll-staging.gemspec
@@ -1,0 +1,18 @@
+# coding: utf-8
+
+Gem::Specification.new do |spec|
+  spec.name          = "jekyll-staging"
+  spec.version       = "1.0.0"
+  spec.authors       = ["Matt Gemmell"]
+  spec.email         = ["matt@mattgemmell.com"]
+  spec.summary       = %q{Stage and unstage draft posts in Jekyll.}
+  spec.homepage      = "https://github.com/mattgemmell/Jekyll-Staging"
+  spec.license       = "MIT"
+
+  spec.files         = `git ls-files -z`.split("\x0")
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "rake", "~> 10.0"
+end


### PR DESCRIPTION
This pull request transforms this script into a [RubyGem](https://rubygems.org), just like Jekyll. Versioning and distributing the code using RubyGems will prevent some frustrating problems down the road, many of which Octopress has encountered.

Users can install it via `gem install jekyll-staging`. Once that is complete, they may start using the `stage` command.

To release a new version, edit the version in jekyll-staging.gemspec, then run:
1. `bundle install`
2. `bundle exec rake release`

The first time you release, you'll need an account on [rubygems.org](https://rubygems.org/sign_up) if you don't already have one and will need to run `gem login` in your terminal. Then, you can run `bundle exec rake release` and push your gems up for distribution.
- [x] Gemify
- [x] Alternate strategy for configuration (configuration file)
